### PR TITLE
Changed the asciidoc documentation link.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Brewtarget's manual are meant to be available in multiple locales to suit the ne
 
 ## AsciiDoc
 "AsciiDoc is a human-readable document format, semantically equivalent to DocBook XML, but using plain-text mark-up conventions. AsciiDoc documents can be created using any text editor and read “as-is”, or rendered to HTML or any other format supported by a DocBook tool-chain, i.e. PDF, TeX, Unix manpages, e-books, slide presentations, etc" (Wikipedia)
-For more information http://powerman.name/doc/asciidoc.
+For more information http://asciidoctor.org/docs/user-manual/.
 
 # Building manuals
 


### PR DESCRIPTION
- The first link referred to a independent blog. This one is the
  official. It's also clearer and more up-to-date.
