### PR TITLE
Closes Brewtarget bug #54 in 2.4.0

### DIFF
--- a/en/02/02.adoc
+++ b/en/02/02.adoc
@@ -104,8 +104,11 @@ There are four main sections on the brewnote tab.
 |Volume
 |The volume of wort that made it into your boil kettle
 
+|Strike Temp
+|The temperature of the strike water before dough in
+
 |Final temp
-|The temperature of your mash after dough in
+|The temperature of your mash before mash out
 
 2+^h|Postboil
 


### PR DESCRIPTION
Brings the manual description of the strike temp and final temp on the BrewNote widget into agreement with the tool tips.

This should be accepted when my [matching PR](https://github.com/Brewtarget/brewtarget/pull/363) in Brewtarget is accepted and version 2.4.0 is released.