### PR TITLE
Bump version to match main repo (3.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In the meantime, one of the easiest solution to generate the manual is through D
 
 ```{bash}
 # Example for the english manual.
-docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf en/book.adoc -o build/pdf/en/brewtarget-2.3.pdf
+docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf en/book.adoc -o build/pdf/en/brewtarget-3.0.3.pdf
 # Example for the english webpage
-docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor en/book.adoc -o build/html/en/brewtarget-2.3.html && cp -r en/assets build/html/en
+docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor en/book.adoc -o build/html/en/brewtarget-3.0.3.html && cp -r en/assets build/html/en
 ```

--- a/en/book.adoc
+++ b/en/book.adoc
@@ -4,7 +4,7 @@
 
 = Brewtarget
 By Philip G. Lee
-v2.3
+v3.0.3
 
 include::README.adoc[]
 

--- a/fr/book.adoc
+++ b/fr/book.adoc
@@ -4,7 +4,7 @@
 
 = Brewtarget
 Par Philip G. Lee
-v2.3
+v3.0.3
 
 include::README.adoc[]
 


### PR DESCRIPTION
This is an update in name only. The manual itself contains many references that are likely outdated by now.